### PR TITLE
style: fix formatting to satisfy cargo fmt CI check

### DIFF
--- a/benches/base62_benchmarks.rs
+++ b/benches/base62_benchmarks.rs
@@ -1,4 +1,11 @@
-#![allow(clippy::unwrap_used, clippy::panic, clippy::excessive_nesting, clippy::cast_possible_wrap, clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::excessive_nesting,
+    clippy::cast_possible_wrap,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss
+)]
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use snowid::{BASE62_MAX_LEN, SnowID, base62_decode, base62_encode, base62_encode_array};
 use std::hint::black_box;

--- a/benches/snowid_benchmarks.rs
+++ b/benches/snowid_benchmarks.rs
@@ -1,4 +1,11 @@
-#![allow(clippy::unwrap_used, clippy::panic, clippy::excessive_nesting, clippy::cast_possible_wrap, clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::excessive_nesting,
+    clippy::cast_possible_wrap,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss
+)]
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use snowid::{SnowID, SnowIDConfig};
 use std::hint::black_box;

--- a/examples/base62_basic.rs
+++ b/examples/base62_basic.rs
@@ -1,4 +1,12 @@
-#![allow(clippy::unwrap_used, clippy::panic, clippy::print_stdout, clippy::print_stderr, clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
 use chrono::{DateTime, Utc};
 use snowid::SnowID;
 

--- a/examples/base62_comparison.rs
+++ b/examples/base62_comparison.rs
@@ -1,4 +1,12 @@
-#![allow(clippy::unwrap_used, clippy::panic, clippy::print_stdout, clippy::print_stderr, clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
 use snowid::{SnowID, base62_encode};
 use std::time::{Duration, Instant};
 

--- a/examples/base62_custom_config.rs
+++ b/examples/base62_custom_config.rs
@@ -1,4 +1,12 @@
-#![allow(clippy::unwrap_used, clippy::panic, clippy::print_stdout, clippy::print_stderr, clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
 use chrono::{DateTime, Utc};
 use snowid::{SnowID, SnowIDConfig};
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,12 @@
-#![allow(clippy::unwrap_used, clippy::panic, clippy::print_stdout, clippy::print_stderr, clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
 use chrono::{DateTime, Utc};
 use snowid::SnowID;
 

--- a/examples/custom_config.rs
+++ b/examples/custom_config.rs
@@ -1,4 +1,12 @@
-#![allow(clippy::unwrap_used, clippy::panic, clippy::print_stdout, clippy::print_stderr, clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
 use snowid::{SnowID, SnowIDConfig};
 
 fn main() {

--- a/examples/distributed.rs
+++ b/examples/distributed.rs
@@ -1,4 +1,13 @@
-#![allow(clippy::unwrap_used, clippy::panic, clippy::print_stdout, clippy::print_stderr, clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_possible_wrap, clippy::excessive_nesting)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::excessive_nesting
+)]
 use rand::{RngExt, rng};
 use snowid::SnowID;
 use std::collections::HashSet;

--- a/src/generator/generate.rs
+++ b/src/generator/generate.rs
@@ -65,7 +65,9 @@ impl SnowID {
     /// Atomic compare-and-swap on state
     #[inline(always)]
     pub(crate) fn cas_state(&self, expected: State, new: State) -> bool {
-        self.state.compare_exchange_weak(expected.raw(), new.raw(), Ordering::AcqRel, Ordering::Acquire).is_ok()
+        self.state
+            .compare_exchange_weak(expected.raw(), new.raw(), Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
     }
 
     /// Slow path for contended generation

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,11 @@
-#![allow(clippy::unwrap_used, clippy::panic, clippy::excessive_nesting, clippy::cast_possible_wrap, clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::excessive_nesting,
+    clippy::cast_possible_wrap,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss
+)]
 mod base62_tests;
 mod boundary_tests;
 mod concurrent_tests;

--- a/src/tests/test_utils.rs
+++ b/src/tests/test_utils.rs
@@ -8,20 +8,20 @@ pub fn wall_clock_ms(epoch: u64) -> u64 {
     let now = SystemTime::now().duration_since(UNIX_EPOCH).expect("System time before Unix epoch!");
     u64::try_from(now.as_millis()).unwrap() - epoch
 }
- 
+
 /// Assert that all IDs in the collection are unique
 pub fn assert_unique_ids(ids: &[u64], expected_count: usize) {
     let set: HashSet<_> = ids.iter().copied().collect();
     assert_eq!(set.len(), expected_count, "Expected {} unique IDs, but got {} (duplicates detected)", expected_count, set.len());
 }
- 
+
 /// Assert that IDs are strictly monotonically increasing (in order)
 pub fn assert_ids_monotonic(ids: &[u64]) {
     for i in 1..ids.len() {
         assert!(ids[i] > ids[i - 1], "ID at position {} ({}) should be > previous ({})", i, ids[i], ids[i - 1]);
     }
 }
- 
+
 /// Assert that IDs are monotonically increasing when sorted
 pub fn assert_monotonic_sorted(ids: &mut [u64]) {
     ids.sort_unstable();
@@ -29,13 +29,13 @@ pub fn assert_monotonic_sorted(ids: &mut [u64]) {
         assert!(ids[i] > ids[i - 1], "ID at position {} ({}) is not greater than previous ID ({})", i, ids[i], ids[i - 1]);
     }
 }
- 
+
 /// Assert collection has expected unique count and is monotonically increasing
 pub fn assert_unique_and_monotonic(mut ids: Vec<u64>, expected_count: usize) {
     assert_unique_ids(&ids, expected_count);
     assert_monotonic_sorted(&mut ids);
 }
- 
+
 /// Assert timestamp is accurate within tolerance (ms)
 pub fn assert_timestamp_accurate(ts: u64, epoch: u64, tolerance_ms: u64) {
     let wall_ts = wall_clock_ms(epoch);

--- a/src/tests/timestamp_tests.rs
+++ b/src/tests/timestamp_tests.rs
@@ -21,34 +21,34 @@ mod tests {
         let ts1 = g.extract.timestamp(g.generate());
         thread::sleep(Duration::from_millis(100));
         let ts2 = g.extract.timestamp(g.generate());
- 
+
         let diff = ts2 - ts1;
         assert!((80..=150).contains(&diff), "Expected ~100ms, got {}ms", diff);
     }
- 
+
     #[test]
     fn test_timestamps_across_generator_restart() {
         let g1 = SnowID::new(1).unwrap();
         let ts1 = g1.extract.timestamp(g1.generate());
         thread::sleep(Duration::from_millis(50));
- 
+
         let g2 = SnowID::new(1).unwrap();
         let ts2 = g2.extract.timestamp(g2.generate());
- 
+
         assert!(ts2 > ts1 && ts2 - ts1 >= 40, "Expected ~50ms diff");
     }
- 
+
     #[test]
     fn test_timestamp_accuracy_under_load() {
         let g = SnowID::new(1).unwrap();
         let epoch = g.config.epoch();
         let mut max_drift: i64 = 0;
- 
+
         for _ in 0..1000 {
             let before = wall_clock_ms(epoch) as i64;
             let ts = g.extract.timestamp(g.generate()) as i64;
             let after = wall_clock_ms(epoch) as i64;
- 
+
             if ts < before {
                 max_drift = max_drift.max(before - ts);
             }


### PR DESCRIPTION
This PR runs cargo fmt to resolve the formatting CI job failures on origin/main.