### PR TITLE
docs: refresh Base62 benchmark values

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,11 @@ cargo bench --bench perf_hotspots -- "Hotspot Per Thread Generator/threads/8/ops
 | Variant          | Time/ID | Size         | Notes                        |
 |------------------|---------|--------------|------------------------------|
 | Int64            | ~22 ns  | 18-20 digits | Fastest single-ID option     |
-| Base62 (String)  | ~260 ns | 10-11 chars  | Compact, URL-friendly        |
-| Base62 (array)   | ~260 ns | 10-11 chars  | Zero-allocation, hot paths   |
-| Base62 (into)    | ~260 ns | 10-11 chars  | Zero-allocation, reuse buffer|
+| Base62 (String)  | ~40 ns  | 10-11 chars  | Compact, URL-friendly        |
+| Base62 (array)   | ~24 ns  | 10-11 chars  | Zero-allocation, hot paths   |
+| Base62 (into)    | ~24 ns  | 10-11 chars  | Zero-allocation, reuse buffer|
+
+These Base62 numbers include ID generation plus encoding from the targeted `ID Generation Comparison` benchmark.
 
 Base62 encoding provides more compact, URL-friendly IDs. For hot paths, use `generate_base62_array()` or `generate_base62_into()` to avoid heap allocations.
 


### PR DESCRIPTION
## Summary

Refresh the README Base62 performance table with current v3 benchmark data.

The old `~260ns` Base62 rows were stale. I verified this by running only the targeted Base62 comparison benchmark, not the whole benchmark suite.

## Benchmark run

```bash
cargo bench --bench base62_benchmarks -- "ID Generation Comparison"
```

Results:

| Benchmark | Result |
|---|---:|
| `int64_generation` | 22.351-23.043ns |
| `base62_generation_string` | 40.086-40.263ns |
| `base62_generation_array` | 23.777-24.491ns |
| `base62_generation_into` | 23.961-24.183ns |

## README update

- Int64 remains rounded to `~22ns`.
- Base62 String is updated to `~40ns`.
- Base62 array/into are updated to `~24ns`.
- Added a note that these numbers include ID generation plus encoding.

## Verification

- Confirmed stale `~260ns` values are removed from README.
- Branch diff is README-only.
